### PR TITLE
Fixes invalid links on the home page

### DIFF
--- a/js/cta.js
+++ b/js/cta.js
@@ -74,7 +74,7 @@ function renderArticle(article, section, number) {
     article.tags = processTags(article.tags);
     var sectionSelector = "#article" + number;
 
-    var articleHref = "./" + article.url.slice(article.url.indexOf("org") + 4);
+    var articleHref = "./" + article.url.slice(article.url.indexOf("in") + 3);
     var articleStr = "<a href=\"" + articleHref + "\">" + article.title + "</a>";
     $(sectionSelector + " .cta_heading").html(articleStr);
 


### PR DESCRIPTION
Resolves #173 

### Description
Since the `search.json` file has hardcoded links, the [articleHref](https://github.com/IEEE-NITK/ieee-nitk.github.io/blob/master/js/cta.js#L77) variable had the incorrectly sliced string as the links were changed from `ieeenitk.org` to `ieee.nitk.ac.in`.