### PR TITLE
Fix blog footer link which was linking back to baseurl

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -4,7 +4,7 @@
         <div class="row footer-row">
             <div class="col-md-3 colorlib-widget">
                 <h4>About IEEE</h4>
-                <p>A not-for-profit organization, IEEE is the world's largest technical professional organization dedicated 
+                <p>A not-for-profit organization, IEEE is the world's largest technical professional organization dedicated
                     to advancing technology for the benefit of humanity.
                 </p>
                 <p>
@@ -18,7 +18,7 @@
                     <ul class="colorlib-footer-links">
                         <li><a href="/"><i class="fa fa-check"></i> Home</a></li>
                         <li><a href="{{ site.url }}/team.html"><i class="fa fa-check"></i> Team</a></li>
-                        <li><a href="{{ site.baseurl }}/"><i class="fa fa-check"></i> Blog</a></li>
+                        <li><a href="{{ site.url }}/blog/"><i class="fa fa-check"></i> Blog</a></li>
                         <li><a href="{{ site.url }}/gyan/"><i class="fa fa-check"></i> Gyan</a></li>
                         <li><a href="{{ site.url }}/achieve.html"><i class="fa fa-check"></i> Achievements</a></li>
                         <li><a href="publications.html"><i class="fa fa-check"></i> Publications</a></li>
@@ -55,7 +55,7 @@
                         <h2><a href="{{ site.url }}/sight.html"><i class="fa fa-users"></i> &nbsp; SIGHT</a></h2>
                     </div>
                 </div>
-                
+
             </div>
             <div class="col-md-3 colorlib-widget">
                 <h4 class="secondary">Contact Info</h4>
@@ -83,8 +83,8 @@
                 <p>
                     Copyright &copy;
                     <script>document.write(new Date().getFullYear());</script>
-                    All rights reserved | Made with <i class="fa fa-heart" aria-hidden="true"></i> 
-                    by IEEE-NITK, <a href="http://jekyllrb.com/" target="_blank" class="copyright-link">Jekyll</a> 
+                    All rights reserved | Made with <i class="fa fa-heart" aria-hidden="true"></i>
+                    by IEEE-NITK, <a href="http://jekyllrb.com/" target="_blank" class="copyright-link">Jekyll</a>
                     and <a href="https://colorlib.com" target="_blank" class="copyright-link">Colorlib</a>
                     <br>
                 </p>


### PR DESCRIPTION
Updated the blog footer link to link to `{{ site.url }}/blog/` instead of `{{ site.baseurl }}`